### PR TITLE
Make AcCCS usable with different hardware setups

### DIFF
--- a/EVSE.py
+++ b/EVSE.py
@@ -63,7 +63,7 @@ class EVSE:
         self.tcp = _TCPHandler(self)
 
         # I2C bus for relays
-        self.bus = SMBus(1)
+        # self.bus = SMBus(1)
 
         # Constants for i2c controlled relays
         self.I2C_ADDR = 0x20
@@ -75,7 +75,7 @@ class EVSE:
     # Start the emulator
     def start(self):
         # Initialize the I2C bus for wwrite
-        self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
+        # self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
 
         self.toggleProximity()
         self.doSLAC()
@@ -90,15 +90,15 @@ class EVSE:
     def closeProximity(self):
         if self.modified_cordset:
             print("INFO (EVSE): Closing CP/PP relay connections")
-            self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_PP | self.EVSE_CP)
+            # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_PP | self.EVSE_CP)
         else:
             print("INFO (EVSE): Closing CP relay connection")
-            self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_CP)
+            # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_CP)
 
     # Close the circuit for the proximity pins
     def openProximity(self):
         print("INFO (EVSE): Opening CP/PP relay connections")
-        self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.ALL_OFF)
+        # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.ALL_OFF)
 
     # Opens and closes proximity circuit with a delay
     def toggleProximity(self, t: int = 5):

--- a/EVSE.py
+++ b/EVSE.py
@@ -30,6 +30,7 @@ class EVSE:
 
     def __init__(self, args):
         self.mode = RunMode(args.mode[0]) if args.mode else RunMode.FULL
+        self.disable_i2c = True if args.disable_i2c else False
         self.iface = args.interface[0] if args.interface else "eth1"
         self.sourceMAC = args.source_mac[0] if args.source_mac else "00:1e:c0:f2:6c:a0"
         self.sourceIP = args.source_ip[0] if args.source_ip else "fe80::21e:c0ff:fef2:6ca0"
@@ -63,7 +64,8 @@ class EVSE:
         self.tcp = _TCPHandler(self)
 
         # I2C bus for relays
-        # self.bus = SMBus(1)
+        if not self.disable_i2c:
+            self.bus = SMBus(1)
 
         # Constants for i2c controlled relays
         self.I2C_ADDR = 0x20
@@ -75,7 +77,8 @@ class EVSE:
     # Start the emulator
     def start(self):
         # Initialize the I2C bus for wwrite
-        # self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
+        if not self.disable_i2c:
+            self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
 
         self.toggleProximity()
         self.doSLAC()
@@ -88,17 +91,23 @@ class EVSE:
 
     # Close the circuit for the proximity pins
     def closeProximity(self):
+        if self.disable_i2c:
+            return
+
         if self.modified_cordset:
             print("INFO (EVSE): Closing CP/PP relay connections")
-            # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_PP | self.EVSE_CP)
+            self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_PP | self.EVSE_CP)
         else:
             print("INFO (EVSE): Closing CP relay connection")
-            # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_CP)
+            self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.EVSE_CP)
 
     # Close the circuit for the proximity pins
     def openProximity(self):
+        if self.disable_i2c:
+            return
+
         print("INFO (EVSE): Opening CP/PP relay connections")
-        # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.ALL_OFF)
+        self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.ALL_OFF)
 
     # Opens and closes proximity circuit with a delay
     def toggleProximity(self, t: int = 5):
@@ -713,6 +722,7 @@ if __name__ == "__main__":
     parser.add_argument("--nmap-mac", nargs=1, help="The MAC address of the target device to NMAP scan (default: EVCC MAC address)")
     parser.add_argument("--nmap-ip", nargs=1, help="The IP address of the target device to NMAP scan (default: EVCC IP address)")
     parser.add_argument("--nmap-ports", nargs=1, help="List of ports to scan seperated by commas (ex. 1,2,5-10,19,...) (default: Top 8000 common ports)")
+    parser.add_argument("--disable-i2c", action="store_true", help="Set this option when not using the original AcCCS hardware, i.e. no I2C bus is present. (default: False)")
     parser.add_argument("--modified-cordset", action="store_true", help="Set this option when using a modified cordset during testing of a target vehicle. The AcCCS system will provide a 150 ohm ground on the proximity line to reset the connection. (default: False)")
     args = parser.parse_args()
 

--- a/EVSE.py
+++ b/EVSE.py
@@ -30,6 +30,7 @@ class EVSE:
 
     def __init__(self, args):
         self.mode = RunMode(args.mode[0]) if args.mode else RunMode.FULL
+        self.skip_slac = True if args.skip_slac else False
         self.disable_i2c = True if args.disable_i2c else False
         self.iface = args.interface[0] if args.interface else "eth1"
         self.sourceMAC = args.source_mac[0] if args.source_mac else "00:1e:c0:f2:6c:a0"
@@ -81,7 +82,8 @@ class EVSE:
             self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
 
         self.toggleProximity()
-        self.doSLAC()
+        if not self.skip_slac:
+            self.doSLAC()
         self.doSDP()
         self.doTCP()
         # If NMAP is not done, restart connection
@@ -722,6 +724,7 @@ if __name__ == "__main__":
     parser.add_argument("--nmap-mac", nargs=1, help="The MAC address of the target device to NMAP scan (default: EVCC MAC address)")
     parser.add_argument("--nmap-ip", nargs=1, help="The IP address of the target device to NMAP scan (default: EVCC IP address)")
     parser.add_argument("--nmap-ports", nargs=1, help="List of ports to scan seperated by commas (ex. 1,2,5-10,19,...) (default: Top 8000 common ports)")
+    parser.add_argument("--skip-slac", action="store_true", help="Set this option when not using QCA based powerline chip. You will have to handle slac externally. (default: False)")
     parser.add_argument("--disable-i2c", action="store_true", help="Set this option when not using the original AcCCS hardware, i.e. no I2C bus is present. (default: False)")
     parser.add_argument("--modified-cordset", action="store_true", help="Set this option when using a modified cordset during testing of a target vehicle. The AcCCS system will provide a 150 ohm ground on the proximity line to reset the connection. (default: False)")
     args = parser.parse_args()

--- a/PEV.py
+++ b/PEV.py
@@ -32,6 +32,7 @@ class PEV:
 
     def __init__(self, args):
         self.mode = RunMode(args.mode[0]) if args.mode else RunMode.FULL
+        self.skip_slac = True if args.skip_slac else False
         self.disable_i2c = True if args.disable_i2c else False
         self.iface = args.interface[0] if args.interface else "eth1"
         self.sourceMAC = args.source_mac[0] if args.source_mac else "00:1e:c0:f2:6c:a1"
@@ -78,7 +79,8 @@ class PEV:
             self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
 
         self.toggleProximity()
-        self.doSLAC()
+        if not self.skip_slac:
+            self.doSLAC()
         self.doSDP()
         self.doTCP()
         # If NMAP is not done, restart connection
@@ -814,6 +816,7 @@ if __name__ == "__main__":
     parser.add_argument("--nmap-mac", nargs=1, help="The MAC address of the target device to NMAP scan (default: SECC MAC address)")
     parser.add_argument("--nmap-ip", nargs=1, help="The IP address of the target device to NMAP scan (default: SECC IP address)")
     parser.add_argument("--nmap-ports", nargs=1, help="List of ports to scan seperated by commas (ex. 1,2,5-10,19,...) (default: Top 8000 common ports)")
+    parser.add_argument("--skip-slac", action="store_true", help="Set this option when not using QCA based powerline chip. You will have to handle slac externally. (default: False)")
     parser.add_argument("--disable-i2c", action="store_true", help="Set this option when not using the original AcCCS hardware, i.e. no I2C bus is present. (default: False)")
     args = parser.parse_args()
 

--- a/PEV.py
+++ b/PEV.py
@@ -56,6 +56,7 @@ class PEV:
         self.exi = EXIProcessor(self.protocol)
 
         self.slac = _SLACHandler(self)
+        self.sdp = _SDPHandler(self)
         self.tcp = _TCPHandler(self)
 
         # I2C bus for relays
@@ -75,6 +76,7 @@ class PEV:
 
         self.toggleProximity()
         self.doSLAC()
+        self.doSDP()
         self.doTCP()
         # If NMAP is not done, restart connection
         if not self.tcp.finishedNMAP:
@@ -84,6 +86,12 @@ class PEV:
     def doTCP(self):
         self.tcp.start()
         print("INFO (PEV) : Done TCP")
+
+    def doSDP(self):
+        print("INFO (PEV) : Starting SDP")
+        self.sdp.start()
+        self.sdp.sniffThread.join()
+        print("INFO (PEV) : Done SDP")
 
     def doSLAC(self):
         print("INFO (PEV) : Starting SLAC")
@@ -160,11 +168,18 @@ class _SLACHandler:
 
     # Stop the thread when the slac match is done
     def stopSniff(self, pkt):
-        if pkt.haslayer("SECC_ResponseMessage"):
-            self.pev.destinationIP = pkt[SECC_ResponseMessage].TargetAddress
-            self.pev.destinationPort = pkt[SECC_ResponseMessage].TargetPort
+        if pkt.haslayer("CM_SLAC_MATCH_CNF"):
+            print("INFO (PEV) : Recieved SLAC_MATCH_CNF")
+            self.NID = pkt[CM_SLAC_MATCH_CNF].VariableField.NetworkID
+            self.NMK = pkt[CM_SLAC_MATCH_CNF].VariableField.NMK
+            print("INFO (PEV) : Sending SET_KEY_REQ")
+            sendp(self.buildSetKeyReq(), iface=self.iface, verbose=0)
+            time.sleep(3) # give modem some time to reboot
+
             if self.neighborSolicitationThread.running:
                 self.neighborSolicitationThread.stop()
+
+            self.stop = True
             return True
         return False
 
@@ -202,21 +217,6 @@ class _SLACHandler:
             self.timeSinceLastPkt = time.time()
             return
 
-        if pkt.haslayer("CM_SLAC_MATCH_CNF"):
-            print("INFO (PEV) : Recieved SLAC_MATCH_CNF")
-            self.NID = pkt[CM_SLAC_MATCH_CNF].VariableField.NetworkID
-            self.NMK = pkt[CM_SLAC_MATCH_CNF].VariableField.NMK
-            print("INFO (PEV) : Sending SET_KEY_REQ")
-            sendp(self.buildSetKeyReq(), iface=self.iface, verbose=0)
-            self.stop = True
-            Thread(target=self.sendSECCRequest).start()
-            return
-
-    def sendSECCRequest(self):
-        time.sleep(3)
-        print("INFO (PEV) : Sending 3 SECC_RequestMessage")
-        for i in range(1):
-            sendp(self.buildSECCRequest(), iface=self.iface, verbose=0)
 
     def sendSounds(self):
         self.numRemainingSounds = self.numSounds
@@ -344,31 +344,6 @@ class _SLACHandler:
         responsePacket = ethLayer / homePlugAVLayer / homePlugLayer
         return responsePacket
 
-    def buildSECCRequest(self):
-        ethLayer = Ether()
-        ethLayer.src = self.sourceMAC
-        ethLayer.dst = "33:33:00:00:00:01"
-
-        ipLayer = IPv6()
-        ipLayer.src = self.sourceIP
-        ipLayer.dst = "ff02::1"
-        ipLayer.hlim = 255
-
-        udpLayer = UDP()
-        udpLayer.sport = self.pev.sourcePort
-        udpLayer.dport = 15118
-
-        seccLayer = SECC()
-        seccLayer.SECCType = 0x9000
-        seccLayer.PayloadLen = 2
-
-        seccRequestLayer = SECC_RequestMessage()
-        seccRequestLayer.SecurityProtocol = 16
-        seccRequestLayer.TransportProtocol = 0
-
-        responsePacket = ethLayer / ipLayer / udpLayer / seccLayer / seccRequestLayer
-        return responsePacket
-
     def buildNeighborAdvertisement(self):
         ethLayer = Ether()
         ethLayer.src = self.sourceMAC
@@ -402,6 +377,60 @@ class _SLACHandler:
         # print("INFO (EVSE): Sending Neighor Advertisement")
         sendp(self.buildNeighborAdvertisement(), iface=self.iface, verbose=0)
 
+class _SDPHandler:
+    def __init__(self, pev: PEV):
+        self.pev = pev
+
+    # This method starts the slac process and will stop
+    def start(self):
+        self.runID = os.urandom(8)
+        self.stop = False
+        # Thread for sniffing packets and handling responses
+        # self.sniffThread = Thread(target=self.startSniff)
+        # self.sniffThread.start()
+
+        self.sniffThread = AsyncSniffer(iface=self.pev.iface, stop_filter=self.stopSniff)
+        self.sniffThread.start()
+
+        self.sendSECCRequest()
+
+    # Stop the thread when the slac match is done
+    def stopSniff(self, pkt):
+        if pkt.haslayer("SECC_ResponseMessage"):
+            self.pev.destinationIP = pkt[SECC_ResponseMessage].TargetAddress
+            self.pev.destinationPort = pkt[SECC_ResponseMessage].TargetPort
+            return True
+        return False
+
+    def sendSECCRequest(self):
+        print("INFO (PEV) : Sending 3 SECC_RequestMessage")
+        for i in range(1):
+            sendp(self.buildSECCRequest(), iface=self.pev.iface, verbose=0)
+
+    def buildSECCRequest(self):
+        ethLayer = Ether()
+        ethLayer.src = self.pev.sourceMAC
+        ethLayer.dst = "33:33:00:00:00:01"
+
+        ipLayer = IPv6()
+        ipLayer.src = self.pev.sourceIP
+        ipLayer.dst = "ff02::1"
+        ipLayer.hlim = 255
+
+        udpLayer = UDP()
+        udpLayer.sport = self.pev.sourcePort
+        udpLayer.dport = 15118
+
+        seccLayer = SECC()
+        seccLayer.SECCType = 0x9000
+        seccLayer.PayloadLen = 2
+
+        seccRequestLayer = SECC_RequestMessage()
+        seccRequestLayer.SecurityProtocol = 16
+        seccRequestLayer.TransportProtocol = 0
+
+        responsePacket = ethLayer / ipLayer / udpLayer / seccLayer / seccRequestLayer
+        return responsePacket
 
 class _TCPHandler:
     def __init__(self, pev: PEV):

--- a/PEV.py
+++ b/PEV.py
@@ -60,7 +60,7 @@ class PEV:
         self.tcp = _TCPHandler(self)
 
         # I2C bus for relays
-        self.bus = SMBus(1)
+        # self.bus = SMBus(1)
 
         # Constants for i2c controlled relays
         self.I2C_ADDR = 0x20
@@ -72,7 +72,7 @@ class PEV:
 
     def start(self):
         # Initialize the smbus for I2C commands
-        self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
+        # self.bus.write_byte_data(self.I2C_ADDR, 0x00, 0x00)
 
         self.toggleProximity()
         self.doSLAC()
@@ -108,13 +108,13 @@ class PEV:
     def setState(self, state: PEVState):
         if state == PEVState.A:
             print("INFO (PEV) : Going to state A")
-            self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.ALL_OFF)
+            # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.ALL_OFF)
         elif state == PEVState.B:
             print("INFO (PEV) : Going to state B")
-            self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.PEV_PP | self.PEV_CP1)
+            # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.PEV_PP | self.PEV_CP1)
         elif state == PEVState.C:
             print("INFO (PEV) : Going to state C")
-            self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.PEV_PP | self.PEV_CP1 | self.PEV_CP2)
+            # self.bus.write_byte_data(self.I2C_ADDR, self.CONTROL_REG, self.PEV_PP | self.PEV_CP1 | self.PEV_CP2)
 
     def toggleProximity(self, t: int = 5):
         self.openProximity()


### PR DESCRIPTION
This PR contains some commits which allow to disable talking to the QCA powerline modem as well as to the I2C relay control.
The goal of this PR is to be able to use AcCCS with different hardware such as VertexCom chips and different mechanisms for doing the low level PWM/resistor handshaking.

In order to achieve this goal this PR not only introduces two new command line flags but also separates SLAC from SDP code, allowing to skip SLAC but using SDP.