### PR TITLE
Add missing PyYAML dependency to requirements.txt (#44)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ smbus==1.1.post2
 sslkeylog==0.5.1
 tqdm==4.67.1
 typing_extensions==4.14.1
+PyYAML==6.0.2
 Requests==2.32.3


### PR DESCRIPTION
Fixes #44.

## Problem

`requirements.txt` never declared **PyYAML**, but `import yaml` is load-bearing in `app/shared/personality/loader.py` and several conformance/personality tests. Clean environments can't even collect the conformance suite (`ModuleNotFoundError: No module named 'yaml'`, 11 collection errors), so the hard `conformance.yml` gate has been **red on every recent commit** (incl. `development` HEAD `a52dadd`). Masked locally because dev conda envs already ship PyYAML.

Surfaced by provisioning the AcCCS-box Pi self-hosted runner (#20) — the first truly clean environment.

## Change

Add `PyYAML==6.0.2` to `requirements.txt` (matches the dev-env version).

## Verification

- Clean `python3.13` venv on the AcCCS-box Pi: `pip install -r requirements.txt` + this change → `pytest tests/conformance/` = **304 passed, 16 skipped** (16 = veth-dependent E2E tests skipping by design).
- Local dev env: **304 passed, 16 skipped**.
- This PR's `conformance.yml` run should now go green (it was failing before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)